### PR TITLE
Fix PropTypes Warning for `component`

### DIFF
--- a/src/TransitionHooks.js
+++ b/src/TransitionHooks.js
@@ -8,7 +8,7 @@ var TransitionHooks = React.createClass({
   propTypes: {
     children: React.PropTypes.node,
     component: React.PropTypes.oneOfType([
-      React.PropTypes.node,
+      React.PropTypes.string,
       React.PropTypes.func,
     ]),
   },

--- a/src/TransitionHooks.js
+++ b/src/TransitionHooks.js
@@ -7,7 +7,11 @@ var TransitionHooks = React.createClass({
 
   propTypes: {
     children: React.PropTypes.node,
-    component: React.PropTypes.string,
+    component: React.PropTypes.oneOfType([
+      React.PropTypes.node,
+      React.PropTypes.func,
+      React.PropTypes.element,
+    ]),
   },
 
   getDefaultProps: function () {

--- a/src/TransitionHooks.js
+++ b/src/TransitionHooks.js
@@ -10,7 +10,6 @@ var TransitionHooks = React.createClass({
     component: React.PropTypes.oneOfType([
       React.PropTypes.node,
       React.PropTypes.func,
-      React.PropTypes.element,
     ]),
   },
 


### PR DESCRIPTION
Same thing as https://github.com/felipethome/react-inline-transition-group/pull/9